### PR TITLE
Adding check if Counter is actually registered before trying to add value

### DIFF
--- a/munin_exporter.go
+++ b/munin_exporter.go
@@ -259,8 +259,12 @@ func fetchMetrics() (err error) {
 			_, isGauge := gaugePerMetric[name]
 			if isGauge {
 				gaugePerMetric[name].WithLabelValues(hostname, graph, key).Set(value)
-			} else {
+				continue
+			}
+			_, isCounter := counterPerMetric[name]
+			if isCounter {
 				counterPerMetric[name].WithLabelValues(hostname, graph, key).Add(value)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
Adding a check for badly written plugins where config returns less values then fetch as munin exporter crashes in that case.